### PR TITLE
fix!: enforce explicit AWS S3 credential boundaries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.2.8
+    rev: v2.2.9
     hooks:
       - id: build-docs
         language: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.16.1
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.43.1
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/NOTICE
+++ b/NOTICE
@@ -665,4 +665,3 @@ Notice:
 
 s3transfer
 Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Publisher: Splunk <br>
 Connector Version: 3.0.0 <br>
 Product Vendor: AWS <br>
 Product Name: S3 <br>
-Minimum Product Version: 5.1.0
+Minimum Product Version: 6.3.0
 
 This app integrates with AWS S3 to perform investigative actions
 
@@ -122,6 +122,7 @@ action_result.summary.num_buckets | numeric | | 4 |
 action_result.message | string | | Num buckets: 4 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'get bucket'
 
@@ -341,6 +342,7 @@ action_result.summary.website_found | boolean | | True False |
 action_result.message | string | | Successfully retrieved bucket info |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'create bucket'
 
@@ -379,6 +381,7 @@ action_result.summary | string | | |
 action_result.message | string | | Successfully created a bucket |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 0 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'update bucket'
 
@@ -425,6 +428,7 @@ action_result.data.\*.ResponseMetadata.RetryAttempts | numeric | | 0 |
 action_result.summary | string | | |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'delete bucket'
 
@@ -461,6 +465,7 @@ action_result.summary | string | | |
 action_result.message | string | | Successfully deleted bucket |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 0 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'list objects'
 
@@ -521,6 +526,7 @@ action_result.summary.num_objects | numeric | | 2 |
 action_result.message | string | | Num objects: 2 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'get object'
 
@@ -611,6 +617,7 @@ action_result.data.\*.Tagging.VersionId | string | | |
 action_result.summary.created_vault_id | string | `sha1` | cde6248b8367f3a87bb6cc3dfc46fb9786200f88 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'update object'
 
@@ -657,6 +664,7 @@ action_result.data.\*.VersionId | string | | |
 action_result.summary | string | | |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'create object'
 
@@ -714,6 +722,7 @@ action_result.summary | string | | |
 action_result.message | string | | Object successfully updated |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'delete object'
 
@@ -752,6 +761,7 @@ action_result.summary | string | | |
 action_result.message | string | | Successfully deleted object |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 0 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'generate presigned url'
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ action_result.summary.num_buckets | numeric | | 4 |
 action_result.message | string | | Num buckets: 4 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'get bucket'
 
@@ -342,7 +341,6 @@ action_result.summary.website_found | boolean | | True False |
 action_result.message | string | | Successfully retrieved bucket info |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'create bucket'
 
@@ -381,7 +379,6 @@ action_result.summary | string | | |
 action_result.message | string | | Successfully created a bucket |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 0 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'update bucket'
 
@@ -428,7 +425,6 @@ action_result.data.\*.ResponseMetadata.RetryAttempts | numeric | | 0 |
 action_result.summary | string | | |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'delete bucket'
 
@@ -465,7 +461,6 @@ action_result.summary | string | | |
 action_result.message | string | | Successfully deleted bucket |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 0 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'list objects'
 
@@ -526,7 +521,6 @@ action_result.summary.num_objects | numeric | | 2 |
 action_result.message | string | | Num objects: 2 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'get object'
 
@@ -617,7 +611,6 @@ action_result.data.\*.Tagging.VersionId | string | | |
 action_result.summary.created_vault_id | string | `sha1` | cde6248b8367f3a87bb6cc3dfc46fb9786200f88 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'update object'
 
@@ -664,7 +657,6 @@ action_result.data.\*.VersionId | string | | |
 action_result.summary | string | | |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'create object'
 
@@ -722,7 +714,6 @@ action_result.summary | string | | |
 action_result.message | string | | Object successfully updated |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'delete object'
 
@@ -761,7 +752,6 @@ action_result.summary | string | | |
 action_result.message | string | | Successfully deleted object |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 0 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'generate presigned url'
 

--- a/README.md
+++ b/README.md
@@ -97,13 +97,12 @@ Read only: **True**
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'} |
 action_result.status | string | | success failed |
 action_result.data.\*.Buckets.\*.Name | string | | aws-athena-query-results-157568067690-us-west-2 |
 action_result.data.\*.Buckets.\*.CreationDate | string | | 2017-09-13 21:33:57 |
@@ -136,7 +135,7 @@ Read only: **True**
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
 **bucket** | required | Bucket to get | string | `aws s3 bucket` |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -144,7 +143,6 @@ DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
 action_result.status | string | | success failed |
 action_result.parameter.bucket | string | `aws s3 bucket` | bucket-test-s3-app |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'} |
 action_result.data.\*.ACL.Grants.\*.Grantee.DisplayName | string | | Display Name |
 action_result.data.\*.ACL.Grants.\*.Grantee.ID | string | | 042b3oe6d5faa5cfe9d016645ce14be41295ed6j94c988c6af6550f439e3f444 |
 action_result.data.\*.ACL.Grants.\*.Grantee.Type | string | | CanonicalUser |
@@ -358,7 +356,7 @@ The bucket will be created in the region specified in the asset configuration. T
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
 **bucket** | required | Name of bucket to create | string | `aws s3 bucket` |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -366,7 +364,6 @@ DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
 action_result.parameter.bucket | string | `aws s3 bucket` | automated-bucket |
 action_result.status | string | | success failed |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'} |
 action_result.data.\*.Location | string | `url` | http://automated-bucket.s3.amazonaws.com/ |
 action_result.data.\*.ResponseMetadata.HTTPHeaders.content-length | numeric | | 72 |
 action_result.data.\*.ResponseMetadata.HTTPHeaders.date | string | | Thu, 04 Jan 2018 01:14:36 GMT |
@@ -402,7 +399,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **kms_key** | optional | KMS Key (Only if encryption is AWS:KMS) | string | |
 **grants** | optional | JSON dictionary of users and the permissions to grant them | string | |
 **owner** | optional | Canonical ID of new owner | string | `aws canonical id` |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -416,7 +413,6 @@ action_result.parameter.kms_key | string | | 28dc6a18-f1ac-11e7-8c3f-9a214cf093a
 action_result.message | string | | Successfully retrieved bucket info |
 action_result.parameter.owner | string | `aws canonical id` | 042b3oe6d5faa5cfe9d016645ce14be41295ed6j94c988c6af6550f439e3f444 |
 action_result.parameter.tags | string | | {"key1": "value1", "key2": "value2"} |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'} |
 action_result.data.\*.ResponseMetadata.HTTPHeaders.content-length | numeric | | 72 |
 action_result.data.\*.ResponseMetadata.HTTPHeaders.date | string | | Fri, 05 Jan 2018 00:10:55 GMT |
 action_result.data.\*.ResponseMetadata.HTTPHeaders.server | string | | AmazonS3 |
@@ -444,7 +440,7 @@ The bucket will be deleted. All objects (including all object versions and delet
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
 **bucket** | required | Name of bucket to delete | string | `aws s3 bucket` |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -452,7 +448,6 @@ DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
 action_result.parameter.bucket | string | `aws s3 bucket` | automated-bucket |
 action_result.status | string | | success failed |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'} |
 action_result.data.\*.ResponseMetadata.HTTPHeaders.content-length | numeric | | 72 |
 action_result.data.\*.ResponseMetadata.HTTPHeaders.date | string | | Thu, 04 Jan 2018 01:14:36 GMT |
 action_result.data.\*.ResponseMetadata.HTTPHeaders.server | string | | AmazonS3 |
@@ -484,7 +479,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **key** | optional | List objects under this key | string | `aws s3 key` |
 **limit** | optional | Max number of objects to list | numeric | |
 **continuation_token** | optional | Use this parameter to get the next set of objects from a previous action | string | `aws s3 continuation token` |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -495,7 +490,6 @@ action_result.parameter.bucket | string | `aws s3 bucket` | bucket-test-s3-app |
 action_result.parameter.continuation_token | string | `aws s3 continuation token` | 1gpyNT6V4At5pjvBmQhRU2D2ehqyGrZJaHJ4VLYm5udxQTTi+8xMyUg== |
 action_result.parameter.key | string | `aws s3 key` | test_folder/deeper_test_folder |
 action_result.parameter.limit | numeric | | 3 |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'} |
 action_result.data.\*.\*.Contents.\*.ETag | string | | "d41d8cd98f00b204e9800998ecf8427e" |
 action_result.data.\*.\*.Contents.\*.StorageClass | string | | STANDARD |
 action_result.data.\*.\*.Contents.\*.Owner.DisplayName | string | | Display Name |
@@ -544,7 +538,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **bucket** | required | Object bucket | string | `aws s3 bucket` |
 **key** | required | Object Key | string | `aws s3 key` |
 **download_file** | optional | Download File | boolean | |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -555,7 +549,6 @@ action_result.message | string | | File successfully added to vault |
 action_result.parameter.bucket | string | `aws s3 bucket` | bucket-test-s3-app |
 action_result.parameter.download_file | boolean | | True False |
 action_result.parameter.key | string | `aws s3 key` | test_folder/image.jpg |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'} |
 action_result.data.\*.ACL.Grants.\*.Grantee.DisplayName | string | | Display Name |
 action_result.data.\*.ACL.Grants.\*.Grantee.ID | string | `sha256` | 042b3oe6d5faa5cfe9d016645ce14be41295ed6j94c988c6af6550f439e3f444 |
 action_result.data.\*.ACL.Grants.\*.Grantee.Type | string | | CanonicalUser |
@@ -637,7 +630,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **grants** | optional | JSON dictionary of users and the permissions to grant them | string | |
 **owner** | optional | Canonical ID of new owner | string | `aws canonical id` |
 **tags** | optional | JSON dictionary containing tags to give object | string | |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -650,7 +643,6 @@ action_result.parameter.grants | string | | {"153b1da9d5faa5cfe9d016645ce14be412
 action_result.parameter.key | string | `aws s3 key` | test_folder/deeper_test_folder/abc.jpg |
 action_result.parameter.owner | string | `aws canonical id` | 042b3oe6d5faa5cfe9d016645ce14be41295ed6j94c988c6af6550f439e3f444 |
 action_result.parameter.tags | string | | {"Adrian Gonzalez": "Braves Legend", "Chipper": "HoFer"} |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'} |
 action_result.data.\*.ResponseMetadata.HTTPHeaders.content-length | numeric | | 72 |
 action_result.data.\*.ResponseMetadata.HTTPHeaders.date | string | | Mon, 18 Dec 2017 21:49:25 GMT |
 action_result.data.\*.ResponseMetadata.HTTPHeaders.server | string | | AmazonS3 |
@@ -686,7 +678,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **encryption** | required | Encryption to apply to object | string | |
 **kms_key** | optional | KMS Key (Only if encryption is AWS:KMS) | string | |
 **metadata** | optional | JSON dictionary containing metadata to give object | string | |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -700,7 +692,6 @@ action_result.parameter.kms_key | string | | 234b9f7cd382ca2affe10176bf2c04aba67
 action_result.parameter.metadata | string | | {"Content-Language": "English"} |
 action_result.parameter.storage_class | string | | STANDARD_IA |
 action_result.parameter.vault_id | string | `vault id` | 306b9e7cd363cb2fdfc11176bc2f04ede7358f00 |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'} |
 action_result.data.\*.ETag | string | | "1dcdb3d256476fe8e2887c146960e580" |
 action_result.data.\*.ResponseMetadata.HTTPHeaders.content-length | numeric | | 72 |
 action_result.data.\*.ResponseMetadata.HTTPHeaders.date | string | | Mon, 18 Dec 2017 23:05:11 GMT |
@@ -739,7 +730,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
 **bucket** | required | Name of the bucket | string | `aws s3 bucket` |
 **key** | required | File include path to be deleted | string | `aws s3 key` |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -748,7 +739,6 @@ DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 action_result.parameter.bucket | string | `aws s3 bucket` | automated-bucket |
 action_result.status | string | | success failed |
 action_result.parameter.key | string | `aws s3 key` | test_folder/deeper_test_folder/abc.jpg |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'} |
 action_result.data.\*.ResponseMetadata.HTTPHeaders.content-length | numeric | | 72 |
 action_result.data.\*.ResponseMetadata.HTTPHeaders.date | string | | Thu, 04 Jan 2018 01:14:36 GMT |
 action_result.data.\*.ResponseMetadata.HTTPHeaders.server | string | | AmazonS3 |

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Validate temporary credentials and prevent action-scoped credentials from replacing asset credentials.
+* Require explicit credentials when role-based authentication is disabled.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Validate temporary credentials and prevent action-scoped credentials from replacing asset credentials.
 * Require explicit credentials when role-based authentication is disabled.
 * Prevent action-scoped AWS credentials from being retained in action results.
+* Require Splunk SOAR 6.3 or later for password-typed action credentials.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Validate temporary credentials and prevent action-scoped credentials from replacing asset credentials.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Validate temporary credentials and prevent action-scoped credentials from replacing asset credentials.
 * Require explicit credentials when role-based authentication is disabled.
+* Prevent action-scoped AWS credentials from being retained in action results.

--- a/s3.json
+++ b/s3.json
@@ -19,7 +19,7 @@
     "utctime_updated": "2026-07-31T00:33:46.719718Z",
     "package_name": "phantom_awss3",
     "main_module": "s3_connector.py",
-    "min_phantom_version": "5.1.0",
+    "min_phantom_version": "6.3.0",
     "latest_tested_versions": [
         "Cloud API, September 13, 2021"
     ],
@@ -289,6 +289,13 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
+                    ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
                     ]
                 }
             ],
@@ -1713,6 +1720,13 @@
                     "example_values": [
                         1
                     ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
+                    ]
                 }
             ],
             "render": {
@@ -1880,6 +1894,13 @@
                     "example_values": [
                         1,
                         0
+                    ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
                     ]
                 }
             ],
@@ -2102,6 +2123,13 @@
                     "example_values": [
                         1
                     ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
+                    ]
                 }
             ],
             "render": {
@@ -2249,6 +2277,13 @@
                     "example_values": [
                         1,
                         0
+                    ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
                     ]
                 }
             ],
@@ -2580,6 +2615,13 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
+                    ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
                     ]
                 }
             ],
@@ -3105,6 +3147,13 @@
                     "example_values": [
                         1
                     ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
+                    ]
                 }
             ],
             "render": {
@@ -3326,6 +3375,13 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
+                    ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
                     ]
                 }
             ],
@@ -3629,6 +3685,13 @@
                     "example_values": [
                         1
                     ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
+                    ]
                 }
             ],
             "render": {
@@ -3798,6 +3861,13 @@
                     "example_values": [
                         1,
                         0
+                    ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
                     ]
                 }
             ],

--- a/s3.json
+++ b/s3.json
@@ -138,7 +138,7 @@
             "parameters": {
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -147,16 +147,6 @@
                 }
             },
             "output": [
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
-                    ]
-                },
                 {
                     "data_path": "action_result.status",
                     "data_type": "string",
@@ -326,7 +316,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -353,16 +343,6 @@
                     ],
                     "example_values": [
                         "bucket-test-s3-app"
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
                     ]
                 },
                 {
@@ -1760,7 +1740,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -1789,16 +1769,6 @@
                     "example_values": [
                         "success",
                         "failed"
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
                     ]
                 },
                 {
@@ -1972,7 +1942,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -2050,16 +2020,6 @@
                     "data_type": "string",
                     "example_values": [
                         "{\"key1\": \"value1\", \"key2\": \"value2\"}"
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
                     ]
                 },
                 {
@@ -2169,7 +2129,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -2198,16 +2158,6 @@
                     "example_values": [
                         "success",
                         "failed"
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
                     ]
                 },
                 {
@@ -2351,7 +2301,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -2405,16 +2355,6 @@
                     "data_type": "numeric",
                     "example_values": [
                         3
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
                     ]
                 },
                 {
@@ -2684,7 +2624,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -2742,16 +2682,6 @@
                     ],
                     "example_values": [
                         "test_folder/image.jpg"
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
                     ]
                 },
                 {
@@ -3231,7 +3161,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -3307,16 +3237,6 @@
                     "data_type": "string",
                     "example_values": [
                         "{\"Adrian Gonzalez\": \"Braves Legend\", \"Chipper\": \"HoFer\"}"
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
                     ]
                 },
                 {
@@ -3488,7 +3408,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -3569,16 +3489,6 @@
                     ],
                     "contains": [
                         "vault id"
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
                     ]
                 },
                 {
@@ -3756,7 +3666,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -3797,16 +3707,6 @@
                     ],
                     "example_values": [
                         "test_folder/deeper_test_folder/abc.jpg"
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': 'REDACTED', 'Expiration': '2020-12-09 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
                     ]
                 },
                 {

--- a/s3.json
+++ b/s3.json
@@ -290,13 +290,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -1720,13 +1713,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -1894,13 +1880,6 @@
                     "example_values": [
                         1,
                         0
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
                     ]
                 }
             ],
@@ -2123,13 +2102,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -2277,13 +2249,6 @@
                     "example_values": [
                         1,
                         0
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
                     ]
                 }
             ],
@@ -2615,13 +2580,6 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
                     ]
                 }
             ],
@@ -3147,13 +3105,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -3375,13 +3326,6 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
                     ]
                 }
             ],
@@ -3685,13 +3629,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -3861,13 +3798,6 @@
                     "example_values": [
                         1,
                         0
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
                     ]
                 }
             ],

--- a/s3_connector.py
+++ b/s3_connector.py
@@ -209,20 +209,19 @@ class AwsS3Connector(BaseConnector):
             secret_key = secret_key.strip()
             self.save_progress("Using temporary assume role credentials for action")
 
+        if not (access_key and secret_key):
+            return action_result.set_status(phantom.APP_ERROR, S3_BAD_ASSET_CONFIG_MESSAGE)
+
         try:
-            if access_key and secret_key:
-                self.debug_print("Creating boto3 client with explicit credentials")
-                self._client = client(
-                    "s3",
-                    region_name=self._region,
-                    aws_access_key_id=access_key,
-                    aws_secret_access_key=secret_key,
-                    aws_session_token=session_token,
-                    config=boto_config,
-                )
-            else:
-                self.debug_print("Creating boto3 client without API keys")
-                self._client = client("s3", region_name=self._region, config=boto_config)
+            self.debug_print("Creating boto3 client with explicit credentials")
+            self._client = client(
+                "s3",
+                region_name=self._region,
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+                aws_session_token=session_token,
+                config=boto_config,
+            )
 
         except Exception as e:
             error_message = self._get_error_message_from_exception(e)

--- a/s3_connector.py
+++ b/s3_connector.py
@@ -182,35 +182,46 @@ class AwsS3Connector(BaseConnector):
         if self._proxy:
             boto_config = Config(proxies=self._proxy)
 
-        # Try getting and using temporary assume role credentials from parameters
-        temp_credentials = dict()
+        access_key = self._access_key
+        secret_key = self._secret_key
+        session_token = self._session_token
+
+        # Try getting and using temporary assume role credentials from parameters.
         if param and "credentials" in param:
             try:
-                temp_credentials = ast.literal_eval(param.get("credentials"))
-                self._access_key = temp_credentials.get("AccessKeyId", "")
-                self._secret_key = temp_credentials.get("SecretAccessKey", "")
-                self._session_token = temp_credentials.get("SessionToken", "")
-
-                self.save_progress("Using temporary assume role credentials for action")
+                raw_credentials = param["credentials"]
+                temp_credentials = raw_credentials if isinstance(raw_credentials, dict) else ast.literal_eval(raw_credentials)
             except Exception as e:
                 return action_result.set_status(phantom.APP_ERROR, f"Failed to get temporary credentials:{e}")
 
-        try:
-            if self._access_key and self._secret_key:
-                self.debug_print("Creating boto3 client with API keys")
+            if not isinstance(temp_credentials, dict):
+                return action_result.set_status(phantom.APP_ERROR, "Temporary credentials must be a dictionary")
 
+            access_key = temp_credentials.get("AccessKeyId")
+            secret_key = temp_credentials.get("SecretAccessKey")
+            session_token = temp_credentials.get("SessionToken")
+            if not isinstance(access_key, str) or not access_key.strip():
+                return action_result.set_status(phantom.APP_ERROR, "Temporary credentials must include a nonblank AccessKeyId")
+            if not isinstance(secret_key, str) or not secret_key.strip():
+                return action_result.set_status(phantom.APP_ERROR, "Temporary credentials must include a nonblank SecretAccessKey")
+
+            access_key = access_key.strip()
+            secret_key = secret_key.strip()
+            self.save_progress("Using temporary assume role credentials for action")
+
+        try:
+            if access_key and secret_key:
+                self.debug_print("Creating boto3 client with explicit credentials")
                 self._client = client(
                     "s3",
                     region_name=self._region,
-                    aws_access_key_id=self._access_key,
-                    aws_secret_access_key=self._secret_key,
-                    aws_session_token=self._session_token,
+                    aws_access_key_id=access_key,
+                    aws_secret_access_key=secret_key,
+                    aws_session_token=session_token,
                     config=boto_config,
                 )
-
             else:
                 self.debug_print("Creating boto3 client without API keys")
-
                 self._client = client("s3", region_name=self._region, config=boto_config)
 
         except Exception as e:

--- a/s3_connector.py
+++ b/s3_connector.py
@@ -52,6 +52,10 @@ class AwsS3Connector(BaseConnector):
         self._boto_config = None
         self._proxy = None
 
+    @staticmethod
+    def _sanitize_action_parameters(param):
+        return {key: value for key, value in param.items() if key != "credentials"}
+
     def initialize(self):
         # Fetching the Python major version
         try:
@@ -303,7 +307,7 @@ class AwsS3Connector(BaseConnector):
 
     def _handle_test_connectivity(self, param):
         self.save_progress("Querying S3 to check credentials")
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         if not self._create_client(action_result, param):
             return action_result.get_status()
@@ -319,7 +323,7 @@ class AwsS3Connector(BaseConnector):
 
     def _handle_list_buckets(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         if not self._create_client(action_result, param):
             return action_result.get_status()
@@ -336,7 +340,7 @@ class AwsS3Connector(BaseConnector):
 
     def _handle_get_bucket(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         if not self._create_client(action_result, param):
             return action_result.get_status()
@@ -377,7 +381,7 @@ class AwsS3Connector(BaseConnector):
 
     def _handle_create_bucket(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         if not self._create_client(action_result, param):
             return action_result.get_status()
@@ -395,7 +399,7 @@ class AwsS3Connector(BaseConnector):
 
     def _handle_update_bucket(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         if not self._create_client(action_result, param):
             return action_result.get_status()
@@ -473,7 +477,7 @@ class AwsS3Connector(BaseConnector):
 
     def _handle_delete_bucket(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         if not self._create_client(action_result, param):
             return action_result.get_status()
@@ -489,7 +493,7 @@ class AwsS3Connector(BaseConnector):
 
     def _handle_list_objects(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         limit = param.get("limit", 1000)
         ret_val, limit = self._validate_integer(action_result, limit, S3_LIMIT)
@@ -552,7 +556,7 @@ class AwsS3Connector(BaseConnector):
 
     def _handle_get_object(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         if not self._create_client(action_result, param):
             return action_result.get_status()
@@ -616,7 +620,7 @@ class AwsS3Connector(BaseConnector):
 
     def _handle_update_object(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         if not self._create_client(action_result, param):
             return action_result.get_status()
@@ -664,7 +668,7 @@ class AwsS3Connector(BaseConnector):
 
     def _handle_delete_object(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         if not self._create_client(action_result, param):
             return action_result.get_status()
@@ -680,7 +684,7 @@ class AwsS3Connector(BaseConnector):
 
     def _handle_post_data(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         if not self._create_client(action_result, param):
             return action_result.get_status()
@@ -740,7 +744,7 @@ class AwsS3Connector(BaseConnector):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
 
         # Add an action result object to self (BaseConnector) to represent the action for this param
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         # Access action parameters passed in the 'param' dictionary
 


### PR DESCRIPTION
Written by Codex with AI assistance.

## Summary

- Validate action-supplied temporary credentials and reject missing, blank, malformed, or incomplete values before boto client creation.
- Keep credentials request-local instead of replacing asset-scoped connector fields.
- Prevent boto3 from discovering ambient host credentials unless an administrator explicitly enables `use_role`.
- Remove credential material from persisted action parameters and remove the corresponding password paths from generated output metadata.

All ten reported S3 actions share this client factory. AWS Athena #33 supplies the corresponding fix for the other two actions in the originating finding.

## Tracking

- [PAPP-38053](https://splunk.atlassian.net/browse/PAPP-38053)
- [PSAAS-31540](https://splunk.atlassian.net/browse/PSAAS-31540)
- [PAPP-37946](https://splunk.atlassian.net/browse/PAPP-37946)
- [PSAAS-32390](https://splunk.atlassian.net/browse/PSAAS-32390)
- [PSAAS-32390](https://splunk.atlassian.net/browse/PSAAS-32390)
- Parent epic: [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228)
- Companion change: [AWS Athena #33](https://github.com/splunk-soar-connectors/awsathena/pull/33)

## Quality gate

- Full pre-commit suite passes locally and the hosted pre-commit check passes at the corrected head.
- Source compilation passes locally.
- The hosted compile retry failed only because the shared target `10.1.65.111` timed out; no connector-code failure was reported.
- This PR remains draft until a hosted compile retry passes.
- Security scans are non-blocking under the connector quality policy; integration failures are ignored unless they implicate the changed code.

## Release impact

This is a breaking change because password-typed action parameters require Splunk SOAR 6.3 or later. Explicit asset credentials and administrator-selected role credentials remain supported; missing or malformed credentials now fail closed.

Merge strategy: merge commit only; do not squash.

## Campaign validation policy

Shared integration, sanity, and `app-tests` coverage-inventory results are out of scope for this work and do not block review. Core source, pre-commit, compile, and build gates pass.

_Updated by Codex._
